### PR TITLE
fix: avoid matching prototype keys in special char map

### DIFF
--- a/src/parser/char.ts
+++ b/src/parser/char.ts
@@ -27,7 +27,7 @@ const newCharTypeSet: { [key in CharType]?: string } = {
   [CharType.FULLWIDTH_BRACKET]: '（）〔〕［］｛｝',
   [CharType.HALFWIDTH_OTHER_PUNCTUATION]: [
     // on-keyboard symbols
-    '~-+*/\\%=&|"`<>@#$^',
+    '~-+*/\\%=&|`<>@#$^',
     // symbol of death
     '†‡'
   ].join(''),

--- a/src/rules/punctuation-unification.ts
+++ b/src/rules/punctuation-unification.ts
@@ -96,14 +96,14 @@ const generateHandler = (options: Options): Handler => {
 
   const handlerPunctuationUnified = (token: MutableToken) => {
     if (token.type === GroupTokenType.GROUP) {
-      if (charMap[token.modifiedStartValue]) {
+      if (Object.prototype.hasOwnProperty.call(charMap, token.modifiedStartValue)) {
         checkStartValue(
           token,
           charMap[token.modifiedStartValue],
           PUNCTUATION_UNIFICATION
         )
       }
-      if (charMap[token.modifiedEndValue]) {
+      if (Object.prototype.hasOwnProperty.call(charMap, token.modifiedEndValue)) {
         checkEndValue(
           token,
           charMap[token.modifiedEndValue],
@@ -112,7 +112,7 @@ const generateHandler = (options: Options): Handler => {
       }
       return
     } else {
-      if (charMap[token.modifiedValue]) {
+      if (Object.prototype.hasOwnProperty.call(charMap, token.modifiedValue)) {
         checkValue(
           token,
           charMap[token.modifiedValue],

--- a/test/uncategorized.test.ts
+++ b/test/uncategorized.test.ts
@@ -182,4 +182,9 @@ import ApiIndex from './ApiIndex.vue'
 `
     expect(getOutput(text, options)).toBe(text)
   })
+  // https://github.com/zhlint-project/zhlint/issues/159
+  test('#159 unexpected function () { [native code] }', () => {
+    const text = `p.toString() 中文`
+    expect(getOutput(text, options)).toBe(text)
+  })
 })


### PR DESCRIPTION
close #159 